### PR TITLE
12 feature auto generate delivery routes on delivery creation

### DIFF
--- a/src/main/java/com/fhsh/daitda/delivery/application/client/CompanyClient.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/client/CompanyClient.java
@@ -1,9 +1,9 @@
 package com.fhsh.daitda.delivery.application.client;
 
-import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfo;
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
 
 import java.util.UUID;
 
 public interface CompanyClient {
-    CompanyHubInfo getHubIdByManagerId(UUID companyId);
+    CompanyHubInfoResponse getHubIdByManagerId(UUID companyId);
 }

--- a/src/main/java/com/fhsh/daitda/delivery/application/client/DeliveryManagerClient.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/client/DeliveryManagerClient.java
@@ -1,7 +1,5 @@
 package com.fhsh.daitda.delivery.application.client;
 
-import com.fhsh.daitda.delivery.application.client.response.DeliveryManagerInfo;
-
 import java.util.UUID;
 
 public interface DeliveryManagerClient {

--- a/src/main/java/com/fhsh/daitda/delivery/application/client/HubClient.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/client/HubClient.java
@@ -1,7 +1,11 @@
 package com.fhsh.daitda.delivery.application.client;
 
+import com.fhsh.daitda.delivery.application.client.response.HubRouteInfoResponse;
+import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
+
 import java.util.UUID;
 
 public interface HubClient {
     UUID getHubIdByManagerId(UUID userId);
+    HubRouteInfoResponse getHubRouteInfo(UUID supplierCompanyId, UUID receiverCompanyId);
 }

--- a/src/main/java/com/fhsh/daitda/delivery/application/client/response/CompanyHubInfoResponse.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/client/response/CompanyHubInfoResponse.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CompanyHubInfo {
+public class CompanyHubInfoResponse {
     private UUID hubId;
     private String address;
     private LocalDateTime receivedAt;

--- a/src/main/java/com/fhsh/daitda/delivery/application/client/response/DeliveryManagerInfoResponse.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/client/response/DeliveryManagerInfoResponse.java
@@ -1,4 +1,4 @@
 package com.fhsh.daitda.delivery.application.client.response;
 
-public class DeliveryManagerInfo {
+public class DeliveryManagerInfoResponse {
 }

--- a/src/main/java/com/fhsh/daitda/delivery/application/client/response/HubRouteInfoResponse.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/client/response/HubRouteInfoResponse.java
@@ -1,0 +1,28 @@
+package com.fhsh.daitda.delivery.application.client.response;
+
+import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class HubRouteInfoResponse {
+    private UUID srcHubId;
+    private UUID destHubId;
+    private int duration;
+    private double distance;
+
+    public HubRouteInfo toHubRouteInfo() {
+        return new HubRouteInfo(
+                this.srcHubId,
+                this.destHubId,
+                this.duration,
+                this.distance
+        );
+    }
+}

--- a/src/main/java/com/fhsh/daitda/delivery/application/service/command/DeliveryCommandService.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/service/command/DeliveryCommandService.java
@@ -2,7 +2,9 @@ package com.fhsh.daitda.delivery.application.service.command;
 
 import com.fhsh.daitda.delivery.application.client.CompanyClient;
 import com.fhsh.daitda.delivery.application.client.DeliveryManagerClient;
-import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfo;
+import com.fhsh.daitda.delivery.application.client.HubClient;
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
+import com.fhsh.daitda.delivery.application.client.response.HubRouteInfoResponse;
 import com.fhsh.daitda.delivery.application.command.DeliveryCreateCommand;
 import com.fhsh.daitda.delivery.application.result.DeliveryStatusUpdateResult;
 import com.fhsh.daitda.delivery.application.result.DeliveryCreateResult;
@@ -24,23 +26,26 @@ import java.util.UUID;
 public class DeliveryCommandService {
 
     private final DeliveryRepository deliveryRepository;
+    private final DeliveryProcessor deliveryProcessor;
     private final DeliveryStateFactory deliveryStateFactory;
     private final DeliveryManagerClient deliveryManagerClient;
     private final CompanyClient companyClient;
-    private final DeliveryProcessor deliveryProcessor;
+    private final HubClient hubClient;
 
     public DeliveryCreateResult registerDelivery(DeliveryCreateCommand command) {
 
         // 공급업체와 수령업체 허브 정보 조회
         // TODO 외부 서비스 호출 실패 시 보상 로직 필요
-        CompanyHubInfo supplierHub = companyClient.getHubIdByManagerId(command.getSupplierCompanyId());
-        CompanyHubInfo receiverHub = companyClient.getHubIdByManagerId(command.getReceiverCompanyId());
+        CompanyHubInfoResponse supplierHubResponse = companyClient.getHubIdByManagerId(command.getSupplierCompanyId());
+        CompanyHubInfoResponse receiverHubResponse = companyClient.getHubIdByManagerId(command.getReceiverCompanyId());
+        // TODO: 허브 서비스 전체 경로 조회 API 연동 필요 (현재 단일 구간만 제공)
+        HubRouteInfoResponse hubRouteInfoResponse = hubClient.getHubRouteInfo(command.getSupplierCompanyId(), command.getReceiverCompanyId()); // domainVO랑 이름 같아서 혼동
 
         // DB 작업
-        Delivery delivery = deliveryProcessor.createAndSave(command, supplierHub, receiverHub);
+        Delivery delivery = deliveryProcessor.createAndSave(command, supplierHubResponse, receiverHubResponse, hubRouteInfoResponse);
 
         // 담당자 배정
-        UUID managerId = deliveryManagerClient.assignCompanyDeliveryManager(delivery.getId(), receiverHub.getHubId());
+        UUID managerId = deliveryManagerClient.assignCompanyDeliveryManager(delivery.getId(), receiverHubResponse.getHubId());
 
         // 담당자 업데이트
         return deliveryProcessor.assignManager(delivery, managerId);

--- a/src/main/java/com/fhsh/daitda/delivery/application/service/command/DeliveryProcessor.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/service/command/DeliveryProcessor.java
@@ -1,14 +1,18 @@
 package com.fhsh.daitda.delivery.application.service.command;
 
-import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfo;
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
+import com.fhsh.daitda.delivery.application.client.response.HubRouteInfoResponse;
 import com.fhsh.daitda.delivery.application.command.DeliveryCreateCommand;
 import com.fhsh.daitda.delivery.application.result.DeliveryCreateResult;
 import com.fhsh.daitda.delivery.domain.entity.Delivery;
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
 import com.fhsh.daitda.delivery.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -31,8 +35,21 @@ public class DeliveryProcessor {
     private final DeliveryRepository deliveryRepository;
 
     @Transactional
-    public Delivery createAndSave(DeliveryCreateCommand command, CompanyHubInfo supplierHub, CompanyHubInfo receiverHub) {
-        Delivery delivery = Delivery.create(command, supplierHub, receiverHub);
+    public Delivery createAndSave(DeliveryCreateCommand command,
+                                  CompanyHubInfoResponse supplierHubResponse,
+                                  CompanyHubInfoResponse receiverHubResponse,
+                                  HubRouteInfoResponse hubRouteInfoResponse) {
+
+        Delivery delivery = Delivery.create(command, supplierHubResponse, receiverHubResponse);
+
+        List<DeliveryRoute> routes = new ArrayList<>();
+
+        DeliveryRoute deliveryRoute = DeliveryRoute.create(delivery, hubRouteInfoResponse.toHubRouteInfo(), 1);
+
+        routes.add(deliveryRoute);
+
+        delivery.addRoutes(routes);
+
         return deliveryRepository.save(delivery);
     }
 

--- a/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
@@ -84,9 +84,6 @@ public class Delivery extends BaseUserEntity {
     }
 
     public void softDelete(){
-        if (this.deletedAt != null) {
-            throw new BusinessException(DeliveryErrorCode.ALREADY_DELETED);
-        }
-        this.deletedAt = LocalDateTime.now();
+        super.delete(deletedBy);
     }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
@@ -1,6 +1,6 @@
 package com.fhsh.daitda.delivery.domain.entity;
 
-import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfo;
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
 import com.fhsh.daitda.delivery.application.command.DeliveryCreateCommand;
 import com.fhsh.daitda.delivery.domain.exception.DeliveryErrorCode;
 import com.fhsh.daitda.domain.BaseUserEntity;
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,8 +32,8 @@ public class Delivery extends BaseUserEntity {
     @Column(name = "status", nullable = false, length = 20)
     private DeliveryStatus status = DeliveryStatus.HUB_WAITING;
 
-    @OneToMany(mappedBy = "delivery", fetch = FetchType.LAZY)
-    private List<DeliveryRoute> deliveryRoutes;
+    @OneToMany(mappedBy = "delivery", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    private List<DeliveryRoute> deliveryRoutes = new ArrayList<>();
 
     private UUID departureHubId;
 
@@ -52,7 +53,7 @@ public class Delivery extends BaseUserEntity {
 
     private UUID deliveryManagerId;
 
-    public static Delivery create(DeliveryCreateCommand command, CompanyHubInfo supplierHub, CompanyHubInfo receiverHub) {
+    public static Delivery create(DeliveryCreateCommand command, CompanyHubInfoResponse supplierHub, CompanyHubInfoResponse receiverHub) {
         Delivery delivery = new Delivery();
         delivery.orderId = command.getOrderId();
         delivery.status = DeliveryStatus.HUB_WAITING;
@@ -81,6 +82,10 @@ public class Delivery extends BaseUserEntity {
             throw new BusinessException(DeliveryErrorCode.CANNOT_CANCEL_DELIVERED);
         }
         this.status = DeliveryStatus.CANCELLED;
+    }
+
+    public void addRoutes(List<DeliveryRoute> routes) {
+        this.deliveryRoutes.addAll(routes);
     }
 
     public void softDelete(){

--- a/src/main/java/com/fhsh/daitda/delivery/domain/entity/DeliveryRoute.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/entity/DeliveryRoute.java
@@ -1,8 +1,9 @@
 package com.fhsh.daitda.delivery.domain.entity;
 
-import com.fhsh.daitda.domain.BaseUserEntity;
 import com.fhsh.daitda.delivery.domain.enums.DeliveryRouteStatus;
-import com.fhsh.daitda.delivery.domain.enums.DepartureNodeType;
+import com.fhsh.daitda.delivery.domain.enums.HubNodeType;
+import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
+import com.fhsh.daitda.domain.BaseUserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -32,7 +33,11 @@ public class DeliveryRoute extends BaseUserEntity {
 
     private UUID departureNodeId;
 
-    private DepartureNodeType departureNodeType;
+    private HubNodeType departureNodeType;
+
+    private UUID destinationNodeId;
+
+    private HubNodeType destinationNodeType;
 
     private int duration;
 
@@ -43,4 +48,26 @@ public class DeliveryRoute extends BaseUserEntity {
     private double estimatedDistance;
 
     private UUID deliveryManagerId;
+
+    public static DeliveryRoute create(Delivery delivery, HubRouteInfo hubRouteInfo, int sequence) {
+        DeliveryRoute deliveryRoute = new DeliveryRoute();
+
+        deliveryRoute.delivery = delivery;
+        deliveryRoute.status = DeliveryRouteStatus.HUB_WAITING;
+        deliveryRoute.sequence = sequence;
+        deliveryRoute.departureNodeId = hubRouteInfo.getSrcHubId();
+        deliveryRoute.departureNodeType = HubNodeType.HUB;
+        deliveryRoute.destinationNodeId = hubRouteInfo.getDestHubId();
+        deliveryRoute.destinationNodeType = HubNodeType.HUB;
+
+        // 생성 시점에 허브값 주입, 배송 완료 시 실제 값으로 업데이트
+        deliveryRoute.duration = hubRouteInfo.getDuration();
+        deliveryRoute.distance = hubRouteInfo.getDistance();
+
+        //예상 시간과 거리는 허브간 거리 값 유지
+        deliveryRoute.estimatedDuration = hubRouteInfo.getDuration();
+        deliveryRoute.estimatedDistance = hubRouteInfo.getDistance();
+
+        return deliveryRoute;
+    }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/domain/enums/DepartureNodeType.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/enums/DepartureNodeType.java
@@ -1,4 +1,0 @@
-package com.fhsh.daitda.delivery.domain.enums;
-
-public enum DepartureNodeType {
-}

--- a/src/main/java/com/fhsh/daitda/delivery/domain/enums/HubNodeType.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/enums/HubNodeType.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.delivery.domain.enums;
+
+/*
+* 목적지가 Hub인지 Company 인지 판단합니다.
+* */
+public enum HubNodeType {
+    HUB, COMPANY
+}

--- a/src/main/java/com/fhsh/daitda/delivery/domain/vo/HubRouteInfo.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/vo/HubRouteInfo.java
@@ -1,0 +1,16 @@
+package com.fhsh.daitda.delivery.domain.vo;
+
+import com.fhsh.daitda.delivery.application.client.response.HubRouteInfoResponse;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class HubRouteInfo {
+    private UUID srcHubId;
+    private UUID destHubId;
+    private int duration;
+    private double distance;
+}

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/CompanyAdapter.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/CompanyAdapter.java
@@ -1,7 +1,7 @@
 package com.fhsh.daitda.delivery.infrastructure.external.adapter;
 
 import com.fhsh.daitda.delivery.application.client.CompanyClient;
-import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfo;
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
 import com.fhsh.daitda.delivery.infrastructure.external.feignClient.CompanyFeignClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,7 +14,7 @@ public class CompanyAdapter implements CompanyClient {
     private final CompanyFeignClient companyFeignClient;
 
     @Override
-    public CompanyHubInfo getHubIdByManagerId(UUID companyId) {
+    public CompanyHubInfoResponse getHubIdByManagerId(UUID companyId) {
         return companyFeignClient.getHubIdByManagerId(companyId);
     }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/DeliveryManagerAdapter.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/DeliveryManagerAdapter.java
@@ -21,6 +21,6 @@ public class DeliveryManagerAdapter implements DeliveryManagerClient {
 
     @Override
     public UUID assignCompanyDeliveryManager(UUID deliveryId, UUID hubId) {
-        return deliveryManagerFeignClient.assignCompanyDeliveryManager(new DeliveryManagerAssignRequest(deliveryId));
+        return deliveryManagerFeignClient.assignCompanyDeliveryManager(new DeliveryManagerAssignRequest(deliveryId, hubId));
     }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/DeliveryManagerAdapter.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/DeliveryManagerAdapter.java
@@ -3,6 +3,7 @@ package com.fhsh.daitda.delivery.infrastructure.external.adapter;
 import com.fhsh.daitda.delivery.application.client.DeliveryManagerClient;
 import com.fhsh.daitda.delivery.infrastructure.external.dto.DeliveryManagerAssignRequest;
 import com.fhsh.daitda.delivery.infrastructure.external.feignClient.DeliveryManagerFeignClient;
+import com.fhsh.daitda.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,12 +16,12 @@ public class DeliveryManagerAdapter implements DeliveryManagerClient {
     private final DeliveryManagerFeignClient deliveryManagerFeignClient;
 
     @Override
-    public UUID assignHubDeliveryManager(UUID companyId) {
+    public CommonResponse<UUID> assignHubDeliveryManager(UUID companyId) {
         return null;
     }
 
     @Override
-    public UUID assignCompanyDeliveryManager(UUID deliveryId, UUID hubId) {
+    public CommonResponse<UUID> assignCompanyDeliveryManager(UUID deliveryId, UUID hubId) {
         return deliveryManagerFeignClient.assignCompanyDeliveryManager(new DeliveryManagerAssignRequest(deliveryId, hubId));
     }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/HubAdapter.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/HubAdapter.java
@@ -1,6 +1,8 @@
 package com.fhsh.daitda.delivery.infrastructure.external.adapter;
 
 import com.fhsh.daitda.delivery.application.client.HubClient;
+import com.fhsh.daitda.delivery.application.client.response.HubRouteInfoResponse;
+import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
 import com.fhsh.daitda.delivery.infrastructure.external.feignClient.HubFeignClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,5 +17,10 @@ public class HubAdapter implements HubClient {
     @Override
     public UUID getHubIdByManagerId(UUID userId) {
         return hubFeignClient.getHubIdByManagerId(userId);
+    }
+
+    @Override
+    public HubRouteInfoResponse getHubRouteInfo(UUID supplierCompanyId, UUID receiverCompanyId) {
+        return hubFeignClient.getHubRouteInfo(supplierCompanyId, receiverCompanyId);
     }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/dto/DeliveryManagerAssignRequest.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/dto/DeliveryManagerAssignRequest.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 @AllArgsConstructor
 public class DeliveryManagerAssignRequest {
     UUID deliveryId;
+    UUID hubId;
 }

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/feignClient/CompanyFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/feignClient/CompanyFeignClient.java
@@ -1,6 +1,6 @@
 package com.fhsh.daitda.delivery.infrastructure.external.feignClient;
 
-import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfo;
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,5 +11,5 @@ import java.util.UUID;
 public interface CompanyFeignClient {
 
     @GetMapping("/internal/v1/companies/{companyId}")
-    CompanyHubInfo getHubIdByManagerId(@PathVariable("companyId") UUID companyId);
+    CompanyHubInfoResponse getHubIdByManagerId(@PathVariable("companyId") UUID companyId);
 }

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/feignClient/DeliveryManagerFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/feignClient/DeliveryManagerFeignClient.java
@@ -1,6 +1,7 @@
 package com.fhsh.daitda.delivery.infrastructure.external.feignClient;
 
 import com.fhsh.daitda.delivery.infrastructure.external.dto.DeliveryManagerAssignRequest;
+import com.fhsh.daitda.response.CommonResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/feignClient/HubFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/feignClient/HubFeignClient.java
@@ -1,8 +1,11 @@
 package com.fhsh.daitda.delivery.infrastructure.external.feignClient;
 
+import com.fhsh.daitda.delivery.application.client.response.HubRouteInfoResponse;
+import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
@@ -12,5 +15,6 @@ public interface HubFeignClient {
     @GetMapping("/internal/v1/hubs/{userId}")
     UUID getHubIdByManagerId(@PathVariable("userId") UUID userId);
 
-
+    @GetMapping("/internal/v1/hubs")
+    HubRouteInfoResponse getHubRouteInfo(@RequestParam UUID supplierCompanyId, @RequestParam UUID receiverCompanyId);
 }

--- a/src/test/java/com/fhsh/daitda/delivery/application/service/command/DeliveryCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/delivery/application/service/command/DeliveryCommandServiceTest.java
@@ -2,7 +2,7 @@ package com.fhsh.daitda.delivery.application.service.command;
 
 import com.fhsh.daitda.delivery.application.client.CompanyClient;
 import com.fhsh.daitda.delivery.application.client.DeliveryManagerClient;
-import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfo;
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
 import com.fhsh.daitda.delivery.application.command.DeliveryCreateCommand;
 import com.fhsh.daitda.delivery.application.result.DeliveryCreateResult;
 import com.fhsh.daitda.delivery.domain.entity.Delivery;
@@ -43,14 +43,14 @@ class DeliveryCommandServiceTest {
                 UUID.randomUUID()
         );
 
-        CompanyHubInfo supplierHub = new CompanyHubInfo(UUID.randomUUID(), "서울시", LocalDateTime.now(), "홍길동");
-        CompanyHubInfo receiverHub = new CompanyHubInfo(UUID.randomUUID(), "부산시", LocalDateTime.now(), "김철수");
+        CompanyHubInfoResponse supplierHub = new CompanyHubInfoResponse(UUID.randomUUID(), "서울시", LocalDateTime.now(), "홍길동");
+        CompanyHubInfoResponse receiverHub = new CompanyHubInfoResponse(UUID.randomUUID(), "부산시", LocalDateTime.now(), "김철수");
         Delivery delivery = Delivery.create(command, supplierHub, receiverHub);
         UUID managerId = UUID.randomUUID();
 
         given(companyClient.getHubIdByManagerId(command.getSupplierCompanyId())).willReturn(supplierHub);
         given(companyClient.getHubIdByManagerId(command.getReceiverCompanyId())).willReturn(receiverHub);
-        given(deliveryProcessor.createAndSave(command, supplierHub, receiverHub)).willReturn(delivery);
+//        given(deliveryProcessor.createAndSave(command, supplierHub, receiverHub, hubRouteInfo)).willReturn(delivery);
         given(deliveryManagerClient.assignCompanyDeliveryManager(any(), any())).willReturn(managerId);
         given(deliveryProcessor.assignManager(delivery, managerId)).willReturn(DeliveryCreateResult.from(delivery));
 

--- a/src/test/java/com/fhsh/daitda/delivery/application/service/command/DeliveryProcessorTest.java
+++ b/src/test/java/com/fhsh/daitda/delivery/application/service/command/DeliveryProcessorTest.java
@@ -1,0 +1,77 @@
+package com.fhsh.daitda.delivery.application.service.command;
+
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
+import com.fhsh.daitda.delivery.application.client.response.HubRouteInfoResponse;
+import com.fhsh.daitda.delivery.application.command.DeliveryCreateCommand;
+import com.fhsh.daitda.delivery.domain.entity.Delivery;
+import com.fhsh.daitda.delivery.domain.repository.DeliveryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryProcessorTest {
+
+    @InjectMocks
+    private DeliveryProcessor deliveryProcessor;
+
+    @Mock
+    private DeliveryRepository deliveryRepository;
+
+    @Test
+    @DisplayName("배송 생성 시 배송경로가 함께 생성된다")
+    void createAndSave_성공_배송경로생성() {
+        // given
+        UUID supplierHubId = UUID.randomUUID();
+        UUID receiverHubId = UUID.randomUUID();
+
+        DeliveryCreateCommand command = new DeliveryCreateCommand(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID()
+        );
+
+        CompanyHubInfoResponse supplierHub = new CompanyHubInfoResponse(
+                supplierHubId,
+                "서울 공급업체 주소",
+                LocalDateTime.now(),
+                "홍길동"
+        );
+
+        CompanyHubInfoResponse receiverHub = new CompanyHubInfoResponse(
+                receiverHubId,
+                "부산 수령업체 주소",
+                LocalDateTime.now(),
+                "김철수"
+        );
+
+        HubRouteInfoResponse hubRouteInfo = new HubRouteInfoResponse(
+                supplierHubId,
+                receiverHubId,
+                120,
+                350.0
+        );
+
+        given(deliveryRepository.save(any(Delivery.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Delivery result = deliveryProcessor.createAndSave(command, supplierHub, receiverHub, hubRouteInfo);
+
+        // then
+        assertThat(result.getDeliveryRoutes()).hasSize(1);
+        assertThat(result.getDeliveryRoutes().get(0).getSequence()).isEqualTo(1);
+        assertThat(result.getDeliveryRoutes().get(0).getDepartureNodeId()).isEqualTo(supplierHubId);
+        assertThat(result.getDeliveryRoutes().get(0).getDestinationNodeId()).isEqualTo(receiverHubId);
+    }
+}


### PR DESCRIPTION
## 🌱 설명
배송 생성 시 허브 서비스로부터 경로 정보를 조회하여 DeliveryRoute를 자동 생성하는 로직을 추가했습니다.

## 📌 관련 이슈
- close #12

## ✅ 주요 변경 사항
- Delivery 엔티티에 cascade = PERSIST, addRoutes() 추가
- DeliveryRoute 팩토리 메서드 create() 추가
- HubRouteInfo 도메인 VO 생성
- HubRouteInfoResponse에 toHubRouteInfo() 변환 메서드 추가
- DeliveryProcessor.createAndSave()에 경로 생성 로직 연결

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
- 허브 서비스가 현재 단일 구간 조회만 제공하여 임시로 단일 DeliveryRoute만 생성합니다. 전체 경로 조회 API 협의 후 리스트로 교체 예정입니다. (TODO 주석 참고)
- company-service 미개발로 인해 통합 테스트는 전체 연동 완료 후 진행 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 공급처와 수령처 간의 허브 경로 정보 조회 기능 추가

* **리팩토링**
  * 배송 경로 관리 개선 및 목적지 노드 정보 추가
  * 응답 데이터 구조 정규화 및 경로 분류 체계 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->