### PR TITLE
14 feature soft delete delivery routes on delivery cancellation

### DIFF
--- a/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
@@ -82,13 +82,20 @@ public class Delivery extends BaseUserEntity {
             throw new BusinessException(DeliveryErrorCode.CANNOT_CANCEL_DELIVERED);
         }
         this.status = DeliveryStatus.CANCELLED;
+
+        this.deliveryRoutes.stream()
+                .filter(deliveryRoute -> deliveryRoute.getDeletedAt() == null)
+                .forEach(DeliveryRoute::softDelete);
     }
 
     public void addRoutes(List<DeliveryRoute> routes) {
         this.deliveryRoutes.addAll(routes);
     }
 
-    public void softDelete(){
-        super.delete(deletedBy);
+    public void softDelete() {
+        if (this.deletedAt != null) {
+            throw new BusinessException(DeliveryErrorCode.ALREADY_DELETED);
+        }
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/domain/entity/DeliveryRoute.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/entity/DeliveryRoute.java
@@ -2,13 +2,16 @@ package com.fhsh.daitda.delivery.domain.entity;
 
 import com.fhsh.daitda.delivery.domain.enums.DeliveryRouteStatus;
 import com.fhsh.daitda.delivery.domain.enums.HubNodeType;
+import com.fhsh.daitda.delivery.domain.exception.DeliveryErrorCode;
 import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
 import com.fhsh.daitda.domain.BaseUserEntity;
+import com.fhsh.daitda.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -69,5 +72,12 @@ public class DeliveryRoute extends BaseUserEntity {
         deliveryRoute.estimatedDistance = hubRouteInfo.getDistance();
 
         return deliveryRoute;
+    }
+
+    public void softDelete(){
+        if (this.deletedAt != null) {
+            throw new BusinessException(DeliveryErrorCode.ALREADY_DELETED);
+        }
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/test/java/com/fhsh/daitda/delivery/domain/entity/DeliveryTest.java
+++ b/src/test/java/com/fhsh/daitda/delivery/domain/entity/DeliveryTest.java
@@ -1,0 +1,101 @@
+package com.fhsh.daitda.delivery.domain.entity;
+
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
+import com.fhsh.daitda.delivery.application.command.DeliveryCreateCommand;
+import com.fhsh.daitda.delivery.domain.enums.DeliveryStatus;
+import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
+import com.fhsh.daitda.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class DeliveryTest {
+
+    private DeliveryCreateCommand command;
+    private CompanyHubInfoResponse supplierHub;
+    private CompanyHubInfoResponse receiverHub;
+    private HubRouteInfo hubRouteInfo;
+
+    @BeforeEach
+    void setUp() {
+        command = new DeliveryCreateCommand(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID()
+        );
+
+        supplierHub = new CompanyHubInfoResponse(
+                UUID.randomUUID(),
+                "서울 공급업체 주소",
+                LocalDateTime.now(),
+                "홍길동"
+        );
+
+        receiverHub = new CompanyHubInfoResponse(
+                UUID.randomUUID(),
+                "부산 수령업체 주소",
+                LocalDateTime.now(),
+                "김철수"
+        );
+
+        hubRouteInfo = new HubRouteInfo(
+                supplierHub.getHubId(),
+                receiverHub.getHubId(),
+                120,
+                350.0
+        );
+    }
+
+    @Test
+    @DisplayName("배송 취소 시 연관 경로 전체가 논리적 삭제된다")
+    void cancel_성공_배송경로논리적삭제() {
+        // given
+        Delivery delivery = Delivery.create(command, supplierHub, receiverHub);
+        List<DeliveryRoute> routes = List.of(
+                DeliveryRoute.create(delivery, hubRouteInfo, 1),
+                DeliveryRoute.create(delivery, hubRouteInfo, 2)
+        );
+        delivery.addRoutes(routes);
+
+        // when
+        delivery.cancel();
+
+        // then
+        assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.CANCELLED);
+        assertThat(delivery.getDeliveryRoutes())
+                .allMatch(route -> route.getDeletedAt() != null);
+    }
+
+    @Test
+    @DisplayName("완료된 배송은 취소할 수 없다")
+    void cancel_실패_완료된배송() {
+        // given
+        Delivery delivery = Delivery.create(command, supplierHub, receiverHub);
+        delivery.changeStatus(DeliveryStatus.COMPLETE);
+
+        // when & then
+        assertThatThrownBy(() -> delivery.cancel())
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("경로가 없는 배송 취소 시 정상 처리된다")
+    void cancel_성공_경로없음() {
+        // given
+        Delivery delivery = Delivery.create(command, supplierHub, receiverHub);
+
+        // when
+        delivery.cancel();
+
+        // then
+        assertThat(delivery.getStatus()).isEqualTo(DeliveryStatus.CANCELLED);
+        assertThat(delivery.getDeliveryRoutes()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 🌱 설명
배송 취소 시 연관된 배송경로 전체를 논리적 삭제(soft delete)하는 로직을 추가했습니다.

## 📌 관련 이슈
- close #14

## ✅ 주요 변경 사항
- DeliveryRoute에 softDelete() 메서드 추가
- Delivery.cancel()에서 연관 경로 전체 논리적 삭제 처리
- 도메인 단위 테스트 3케이스 추가 (정상/완료배송취소/경로없음)

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
- Delivery가 Aggregate Root로서 DeliveryRoute의 생명주기를 관리하는 구조로 구현했습니다.
- 이미 삭제된 경로는 filter로 제외하고 미삭제 경로만 soft delete 처리합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배송 생성 시 허브 간 배송경로 정보를 자동으로 생성 및 관리

* **개선 사항**
  * 배송 취소 시 관련 배송경로에 대한 삭제 처리 추가
  * 허브 간 경로 정보 조회 기능 확대

* **테스트**
  * 배송경로 생성 및 취소 동작에 대한 테스트 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->