### PR TITLE
16 feature implement delivery route read apis

### DIFF
--- a/src/main/java/com/fhsh/daitda/delivery/application/result/DeliveryRouteResult.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/result/DeliveryRouteResult.java
@@ -1,0 +1,45 @@
+package com.fhsh.daitda.delivery.application.result;
+
+import com.fhsh.daitda.delivery.domain.entity.Delivery;
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
+import com.fhsh.daitda.delivery.domain.enums.DeliveryRouteStatus;
+import com.fhsh.daitda.delivery.domain.enums.HubNodeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryRouteResult {
+
+    private UUID id;
+    private UUID deliveryId;
+    private DeliveryRouteStatus status;
+    private int sequence;
+    private UUID departureNodeId;
+    private HubNodeType departureNodeType;
+    private UUID destinationNodeId;
+    private HubNodeType destinationNodeType;
+    private int duration;
+    private double distance;
+    private int estimatedDuration;
+    private double estimatedDistance;
+
+    public static DeliveryRouteResult from(DeliveryRoute deliveryRoute) {
+        return new DeliveryRouteResult(
+                deliveryRoute.getId(),
+                deliveryRoute.getDelivery().getId(),
+                deliveryRoute.getStatus(),
+                deliveryRoute.getSequence(),
+                deliveryRoute.getDepartureNodeId(),
+                deliveryRoute.getDepartureNodeType(),
+                deliveryRoute.getDestinationNodeId(),
+                deliveryRoute.getDestinationNodeType(),
+                deliveryRoute.getDuration(),
+                deliveryRoute.getDistance(),
+                deliveryRoute.getEstimatedDuration(),
+                deliveryRoute.getEstimatedDistance()
+        );
+    }
+}

--- a/src/main/java/com/fhsh/daitda/delivery/application/service/query/DeliveryRouteQueryService.java
+++ b/src/main/java/com/fhsh/daitda/delivery/application/service/query/DeliveryRouteQueryService.java
@@ -1,0 +1,36 @@
+package com.fhsh.daitda.delivery.application.service.query;
+
+import com.fhsh.daitda.delivery.application.result.DeliveryRouteResult;
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
+import com.fhsh.daitda.delivery.domain.exception.DeliveryErrorCode;
+import com.fhsh.daitda.delivery.domain.repository.DeliveryRouteRepository;
+import com.fhsh.daitda.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryRouteQueryService {
+
+    private final DeliveryRouteRepository deliveryRouteRepository;
+
+    public DeliveryRouteResult findDeliveryRoute(UUID deliveryId, int sequence) {
+
+        DeliveryRoute deliveryRoute = deliveryRouteRepository.findByDeliveryIdAndSequenceAndDeletedAtIsNull(deliveryId, sequence)
+                .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
+
+        return DeliveryRouteResult.from(deliveryRoute);
+    }
+
+    public Slice<DeliveryRouteResult> getDeliveryRoutes(UUID deliveryId, Pageable pageable) {
+
+        Slice<DeliveryRoute> deliveryRoutes = deliveryRouteRepository.findByDeliveryIdAndDeletedAtIsNull(deliveryId, pageable);
+        return deliveryRoutes.map(DeliveryRouteResult::from);
+    }
+}

--- a/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/entity/Delivery.java
@@ -92,7 +92,7 @@ public class Delivery extends BaseUserEntity {
         this.deliveryRoutes.addAll(routes);
     }
 
-    public void softDelete() {
+    public void softDelete(){
         if (this.deletedAt != null) {
             throw new BusinessException(DeliveryErrorCode.ALREADY_DELETED);
         }

--- a/src/main/java/com/fhsh/daitda/delivery/domain/exception/DeliveryErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/exception/DeliveryErrorCode.java
@@ -11,7 +11,8 @@ public enum DeliveryErrorCode implements ErrorCode {
     NOT_FOUND_DELIVERY(HttpStatus.NOT_FOUND, "배송을 찾을 수 없습니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 배송 상태 전환입니다."),
     CANNOT_CANCEL_DELIVERED(HttpStatus.BAD_REQUEST, "이미 완료된 배송은 취소할 수 없습니다."),
-    ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 배송입니다.");
+    ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 배송입니다."),
+    NOT_FOUND_DELIVERY_ROUTE(HttpStatus.NOT_FOUND, "배송경로를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/fhsh/daitda/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/src/main/java/com/fhsh/daitda/delivery/domain/repository/DeliveryRouteRepository.java
@@ -1,0 +1,13 @@
+package com.fhsh.daitda.delivery.domain.repository;
+
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryRouteRepository {
+    Optional<DeliveryRoute> findByDeliveryIdAndSequenceAndDeletedAtIsNull(UUID deliveryId, int sequence);
+    Slice<DeliveryRoute> findByDeliveryIdAndDeletedAtIsNull(UUID deliveryId, Pageable pageable);
+}

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/DeliveryManagerAdapter.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/external/adapter/DeliveryManagerAdapter.java
@@ -3,7 +3,6 @@ package com.fhsh.daitda.delivery.infrastructure.external.adapter;
 import com.fhsh.daitda.delivery.application.client.DeliveryManagerClient;
 import com.fhsh.daitda.delivery.infrastructure.external.dto.DeliveryManagerAssignRequest;
 import com.fhsh.daitda.delivery.infrastructure.external.feignClient.DeliveryManagerFeignClient;
-import com.fhsh.daitda.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,12 +15,12 @@ public class DeliveryManagerAdapter implements DeliveryManagerClient {
     private final DeliveryManagerFeignClient deliveryManagerFeignClient;
 
     @Override
-    public CommonResponse<UUID> assignHubDeliveryManager(UUID companyId) {
+    public UUID assignHubDeliveryManager(UUID companyId) {
         return null;
     }
 
     @Override
-    public CommonResponse<UUID> assignCompanyDeliveryManager(UUID deliveryId, UUID hubId) {
+    public UUID assignCompanyDeliveryManager(UUID deliveryId, UUID hubId) {
         return deliveryManagerFeignClient.assignCompanyDeliveryManager(new DeliveryManagerAssignRequest(deliveryId, hubId));
     }
 }

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/persistence/repository/DeliveryRouteJpaRepository.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/persistence/repository/DeliveryRouteJpaRepository.java
@@ -1,0 +1,14 @@
+package com.fhsh.daitda.delivery.infrastructure.persistence.repository;
+
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryRouteJpaRepository extends JpaRepository<DeliveryRoute, UUID> {
+    Optional<DeliveryRoute> findByDeliveryIdAndSequenceAndDeletedAtIsNull(UUID deliveryId, int sequence);
+    Slice<DeliveryRoute> findByDeliveryIdAndDeletedAtIsNull(UUID deliveryId, Pageable pageable);
+}

--- a/src/main/java/com/fhsh/daitda/delivery/infrastructure/persistence/repository/impl/DeliveryRouteRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/delivery/infrastructure/persistence/repository/impl/DeliveryRouteRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.fhsh.daitda.delivery.infrastructure.persistence.repository.impl;
+
+import com.fhsh.daitda.delivery.domain.entity.Delivery;
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
+import com.fhsh.daitda.delivery.domain.repository.DeliveryRepository;
+import com.fhsh.daitda.delivery.domain.repository.DeliveryRouteRepository;
+import com.fhsh.daitda.delivery.infrastructure.persistence.repository.DeliveryJpaRepository;
+import com.fhsh.daitda.delivery.infrastructure.persistence.repository.DeliveryRouteJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryRouteRepositoryImpl implements DeliveryRouteRepository {
+
+    private final DeliveryRouteJpaRepository deliveryRouteJpaRepository;
+
+    @Override
+    public Optional<DeliveryRoute> findByDeliveryIdAndSequenceAndDeletedAtIsNull(UUID deliveryId, int sequence) {
+        return deliveryRouteJpaRepository.findByDeliveryIdAndSequenceAndDeletedAtIsNull(deliveryId, sequence);
+    }
+
+    @Override
+    public Slice<DeliveryRoute> findByDeliveryIdAndDeletedAtIsNull(UUID deliveryId, Pageable pageable) {
+        return deliveryRouteJpaRepository.findByDeliveryIdAndDeletedAtIsNull(deliveryId, pageable);
+    }
+}

--- a/src/main/java/com/fhsh/daitda/delivery/presentation/controller/DeliveryRouteController.java
+++ b/src/main/java/com/fhsh/daitda/delivery/presentation/controller/DeliveryRouteController.java
@@ -1,0 +1,47 @@
+package com.fhsh.daitda.delivery.presentation.controller;
+
+import com.fhsh.daitda.delivery.application.service.query.DeliveryRouteQueryService;
+import com.fhsh.daitda.delivery.presentation.dto.response.DeliveryRouteInfoResponse;
+import com.fhsh.daitda.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/deliveries")
+public class DeliveryRouteController {
+
+    private final DeliveryRouteQueryService deliveryRouteQueryService;
+
+    @GetMapping("/{deliveryId}/routes/{sequence}")
+    public ResponseEntity<CommonResponse<DeliveryRouteInfoResponse>> getDeliveryRoute(
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Email") String email,
+            @RequestHeader("X-User-Role") String role,
+            @PathVariable UUID deliveryId,
+            @PathVariable int sequence
+    ) {
+        DeliveryRouteInfoResponse response = DeliveryRouteInfoResponse.from(deliveryRouteQueryService.findDeliveryRoute(deliveryId, sequence));
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    @GetMapping("/{deliveryId}/routes")
+    public ResponseEntity<CommonResponse<Slice<DeliveryRouteInfoResponse>>> getDeliveries(
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader(value = "X-User-Role") String role,
+            @PathVariable UUID deliveryId,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Slice<DeliveryRouteInfoResponse> responses = deliveryRouteQueryService.getDeliveryRoutes(deliveryId, pageable)
+                .map(DeliveryRouteInfoResponse::from);
+
+        return ResponseEntity.ok(CommonResponse.success(responses));
+    }
+}

--- a/src/main/java/com/fhsh/daitda/delivery/presentation/dto/response/DeliveryRouteInfoResponse.java
+++ b/src/main/java/com/fhsh/daitda/delivery/presentation/dto/response/DeliveryRouteInfoResponse.java
@@ -1,0 +1,45 @@
+package com.fhsh.daitda.delivery.presentation.dto.response;
+
+import com.fhsh.daitda.delivery.application.result.DeliveryRouteResult;
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
+import com.fhsh.daitda.delivery.domain.enums.DeliveryRouteStatus;
+import com.fhsh.daitda.delivery.domain.enums.HubNodeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryRouteInfoResponse {
+
+    private UUID id;
+    private UUID deliveryId;
+    private DeliveryRouteStatus status;
+    private int sequence;
+    private UUID departureNodeId;
+    private HubNodeType departureNodeType;
+    private UUID destinationNodeId;
+    private HubNodeType destinationNodeType;
+    private int duration;
+    private double distance;
+    private int estimatedDuration;
+    private double estimatedDistance;
+
+    public static DeliveryRouteInfoResponse from(DeliveryRouteResult deliveryRouteResult) {
+        return new DeliveryRouteInfoResponse(
+                deliveryRouteResult.getId(),
+                deliveryRouteResult.getDeliveryId(),
+                deliveryRouteResult.getStatus(),
+                deliveryRouteResult.getSequence(),
+                deliveryRouteResult.getDepartureNodeId(),
+                deliveryRouteResult.getDepartureNodeType(),
+                deliveryRouteResult.getDestinationNodeId(),
+                deliveryRouteResult.getDestinationNodeType(),
+                deliveryRouteResult.getDuration(),
+                deliveryRouteResult.getDistance(),
+                deliveryRouteResult.getEstimatedDuration(),
+                deliveryRouteResult.getEstimatedDistance()
+        );
+    }
+}

--- a/src/test/java/com/fhsh/daitda/delivery/application/service/query/DeliveryRouteQueryServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/delivery/application/service/query/DeliveryRouteQueryServiceTest.java
@@ -1,0 +1,116 @@
+package com.fhsh.daitda.delivery.application.service.query;
+
+import com.fhsh.daitda.delivery.application.client.response.CompanyHubInfoResponse;
+import com.fhsh.daitda.delivery.application.command.DeliveryCreateCommand;
+import com.fhsh.daitda.delivery.application.result.DeliveryRouteResult;
+import com.fhsh.daitda.delivery.domain.entity.Delivery;
+import com.fhsh.daitda.delivery.domain.entity.DeliveryRoute;
+import com.fhsh.daitda.delivery.domain.repository.DeliveryRouteRepository;
+import com.fhsh.daitda.delivery.domain.vo.HubRouteInfo;
+import com.fhsh.daitda.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryRouteQueryServiceTest {
+
+    @InjectMocks
+    private DeliveryRouteQueryService deliveryRouteQueryService;
+
+    @Mock
+    private DeliveryRouteRepository deliveryRouteRepository;
+
+    private Delivery delivery;
+    private HubRouteInfo hubRouteInfo;
+
+    @BeforeEach
+    void setUp() {
+        DeliveryCreateCommand command = new DeliveryCreateCommand(
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()
+        );
+        CompanyHubInfoResponse supplierHub = new CompanyHubInfoResponse(
+                UUID.randomUUID(), "서울 공급업체 주소", LocalDateTime.now(), "홍길동"
+        );
+        CompanyHubInfoResponse receiverHub = new CompanyHubInfoResponse(
+                UUID.randomUUID(), "부산 수령업체 주소", LocalDateTime.now(), "김철수"
+        );
+        delivery = Delivery.create(command, supplierHub, receiverHub);
+        hubRouteInfo = new HubRouteInfo(
+                supplierHub.getHubId(), receiverHub.getHubId(), 120, 350.0
+        );
+    }
+
+    @Test
+    @DisplayName("배송경로 단건 정상 반환")
+    void findDeliveryRoute_성공() {
+        // given
+        UUID deliveryId = UUID.randomUUID();
+        int sequence = 1;
+        DeliveryRoute mockRoute = DeliveryRoute.create(delivery, hubRouteInfo, sequence);
+
+        given(deliveryRouteRepository.findByDeliveryIdAndSequenceAndDeletedAtIsNull(deliveryId, sequence))
+                .willReturn(Optional.of(mockRoute));
+
+        // when
+        DeliveryRouteResult result = deliveryRouteQueryService.findDeliveryRoute(deliveryId, sequence);
+
+        // then
+        assertThat(result.getSequence()).isEqualTo(1);
+        assertThat(result.getDepartureNodeId()).isEqualTo(hubRouteInfo.getSrcHubId());
+    }
+
+    @Test
+    @DisplayName("배송경로 목록 정상 반환")
+    void getDeliveryRoutes_성공() {
+        // given
+        UUID deliveryId = UUID.randomUUID();
+        List<DeliveryRoute> mockRoutes = List.of(
+                DeliveryRoute.create(delivery, hubRouteInfo, 1),
+                DeliveryRoute.create(delivery, hubRouteInfo, 2)
+        );
+        Slice<DeliveryRoute> mockSlice = new SliceImpl<>(mockRoutes, PageRequest.of(0, 10), false);
+
+        given(deliveryRouteRepository.findByDeliveryIdAndDeletedAtIsNull(deliveryId, PageRequest.of(0, 10)))
+                .willReturn(mockSlice);
+
+        // when
+        Slice<DeliveryRouteResult> result = deliveryRouteQueryService.getDeliveryRoutes(deliveryId, PageRequest.of(0, 10));
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getSequence()).isEqualTo(1);
+        assertThat(result.getContent().get(1).getSequence()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 배송경로 단건 조회 시 예외 반환")
+    void findDeliveryRoute_실패_없는경로() {
+        // given
+        UUID deliveryId = UUID.randomUUID();
+        int sequence = 999;
+
+        given(deliveryRouteRepository.findByDeliveryIdAndSequenceAndDeletedAtIsNull(deliveryId, sequence))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> deliveryRouteQueryService.findDeliveryRoute(deliveryId, sequence))
+                .isInstanceOf(BusinessException.class);
+    }
+}


### PR DESCRIPTION
## 🌱 설명
배송경로 단건 및 목록 조회 API를 추가했습니다.

## 📌 관련 이슈
- close #16

## ✅ 주요 변경 사항
- DeliveryRouteController 추가 (엔드포인트 분리)
- DeliveryRoute 단건 조회 구현 (`GET /api/v1/deliveries/{deliveryId}/routes/{sequence}`)
- DeliveryRoute 목록 조회 구현 (`GET /api/v1/deliveries/{deliveryId}/routes`)
- DeliveryRouteQueryService, DeliveryRouteRepository 추가

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
- DeliveryRoute는 Delivery의 Aggregate로 관리되므로 별도 생성/삭제 API 없이 배송 생성/취소 로직에 내장되어 있습니다.
- 논리적 삭제된 경로는 조회에서 자동 제외됩니다. (`deleted_at IS NULL`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배송 경로 조회 및 관리 기능 추가: 배송별 경로 정보를 상세하게 확인할 수 있으며, 출발지, 도착지, 소요 시간, 거리 등 세부 정보를 조회할 수 있습니다.
  * 개별 경로 검색: 배송 ID와 순서를 통해 특정 경로 정보를 조회할 수 있습니다.

* **개선 사항**
  * 배송 경로 관리: 경로 데이터의 소프트 삭제 기능이 추가되어 데이터 무결성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->